### PR TITLE
Fix network error handling in mobile scanner

### DIFF
--- a/app/src/main/java/com/example/s3scanner/MainActivity.java
+++ b/app/src/main/java/com/example/s3scanner/MainActivity.java
@@ -64,7 +64,7 @@ public class MainActivity extends AppCompatActivity {
                     @Override
                     public void run() {
                         try {
-                            final S3Scanner.ScanResult result = scanner.scanBucket(bucketName, provider);
+                            final S3Scanner.ScanResultWrapper result = scanner.scanBucket(bucketName, provider);
                             runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {
@@ -89,7 +89,7 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
-    private void displayResult(S3Scanner.ScanResult result) {
+    private void displayResult(S3Scanner.ScanResultWrapper result) {
         if (result.getError() != null) {
             showError(result.getError());
             return;
@@ -121,3 +121,4 @@ public class MainActivity extends AppCompatActivity {
         ).show();
     }
 }
+

--- a/app/src/main/java/com/example/s3scanner/S3Scanner.java
+++ b/app/src/main/java/com/example/s3scanner/S3Scanner.java
@@ -8,16 +8,16 @@ import scanner.ScanResult;
  * Java interface for the S3Scanner Go implementation
  */
 public class S3Scanner {
-    private final MobileScanner scanner;
+    private final MobileScanner mobileScanner;
 
-    public static class ScanResult {
+    public static class ScanResultWrapper {
         private final String bucketName;
         private final String region;
         private final boolean exists;
         private final boolean isPublic;
         private final String error;
 
-        public ScanResult(scanner.ScanResult goResult) {
+        public ScanResultWrapper(scanner.ScanResult goResult) {
             this.bucketName = goResult.getBucketName();
             this.region = goResult.getRegion();
             this.exists = goResult.getExists();
@@ -33,19 +33,19 @@ public class S3Scanner {
     }
 
     public S3Scanner() {
-        this.scanner = Scanner.newMobileScanner();
+        this.mobileScanner = Scanner.newMobileScanner();
     }
 
     public String[] getSupportedProviders() {
         return Scanner.getSupportedProviders();
     }
 
-    public ScanResult scanBucket(String bucketName, String provider) {
-        scanner.ScanResult goResult = scanner.scanBucket(bucketName, provider);
-        return new ScanResult(goResult);
+    public ScanResultWrapper scanBucket(String bucketName, String provider) {
+        scanner.ScanResult goResult = mobileScanner.scanBucket(bucketName, provider);
+        return new ScanResultWrapper(goResult);
     }
 
     public String getVersion() {
-        return scanner.getVersion();
+        return mobileScanner.getVersion();
     }
 }

--- a/mobile/scanner/mobile.go
+++ b/mobile/scanner/mobile.go
@@ -38,10 +38,10 @@ func (p *SimpleMobileProvider) CheckBucket(bucketName string) (*BucketInfo, erro
 
 	resp, err := http.Head(url)
 	if err != nil {
-		// Network error, but bucket might still exist
+		// Propagate network error so the caller can handle it
 		info.Exists = false
 		info.IsPublic = false
-		return info, nil
+		return info, err
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## Summary
- propagate network errors from SimpleMobileProvider.CheckBucket

## Testing
- `go test ./...` *(fails: no Go module)*
- `./gradlew build --dry-run` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_684193ce1b4483288e053fb4fb2d5afe